### PR TITLE
Create Issues and Evidence from Nikto findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
+## Dradis Framework 3.10 (XXX, 2018) ##
+
+*   Create Issues from each finding `id` and a piece of 
+    Evidence for each instance of that finding.
+
+*   Label the Node from the `targetip`.
+
 ## Dradis Framework 3.9 (January, 2018) ##
 
 *   No changes.
 
 ## Dradis Framework 3.8 (September, 2017) ##
 
-*   Create Issues from each finding `id` and a piece of 
-    Evidence for each instance of that finding.
-
-*   Label the Node from the `targetip`.
+*   No changes.
 
 ## Dradis Framework 3.7 (July, 2017) ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Dradis Framework 3.8 (September, 2017) ##
 
-*   No changes.
+*   Create Issues from each finding `id` and a piece of 
+    Evidence for each instance of that finding.
+
+*   Label the Node from the `targetip`.
 
 ## Dradis Framework 3.7 (July, 2017) ##
 

--- a/lib/dradis/plugins/nikto/gem_version.rb
+++ b/lib/dradis/plugins/nikto/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 8
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/nikto/gem_version.rb
+++ b/lib/dradis/plugins/nikto/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 8
-        TINY = 1
+        MINOR = 9
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/spec/nikto_upload_spec.rb
+++ b/spec/nikto_upload_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
+require 'ostruct'
 
-describe 'Nikto upload plugin' do
-  describe "Importer" do
-
+module Dradis::Plugins
+  describe 'Nikto upload plugin' do
     before(:each) do
       # Stub template service
       templates_dir = File.expand_path('../../templates', __FILE__)
@@ -12,12 +12,13 @@ describe 'Nikto upload plugin' do
       # Init services
       plugin = Dradis::Plugins::Nikto
 
-      @content_service = Dradis::Plugins::ContentService.new(plugin: plugin)
-      template_service = Dradis::Plugins::TemplateService.new(plugin: plugin)
+      @content_service = Dradis::Plugins::ContentService::Base.new(
+        logger: Logger.new(STDOUT),
+        plugin: plugin
+      )
 
-      @importer = plugin::Importer.new(
+      @importer = Dradis::Plugins::Nikto::Importer.new(
         content_service: @content_service,
-        template_service: template_service
       )
 
       # Stub dradis-plugins methods
@@ -25,95 +26,86 @@ describe 'Nikto upload plugin' do
       # They return their argument hashes as objects mimicking
       # Nodes, Issues, etc
       allow(@content_service).to receive(:create_node) do |args|
-        puts "create_node: #{ args.inspect }"
         OpenStruct.new(args)
       end
       allow(@content_service).to receive(:create_note) do |args|
-        puts "create_note: #{ args.inspect }"
         OpenStruct.new(args)
       end
       allow(@content_service).to receive(:create_issue) do |args|
-        puts "create_issue: #{ args.inspect }"
         OpenStruct.new(args)
       end
       allow(@content_service).to receive(:create_evidence) do |args|
-        puts "create_evidence: #{ args.inspect }"
         OpenStruct.new(args)
       end
     end
 
-    it "creates nodes, issues, notes and an evidences as needed" do
-      # Host node and basic host info note
+    let(:example_xml) { 'spec/fixtures/files/localhost.xml' }
+
+    def run_import!
+      @importer.import(file: example_xml)
+    end
+
+    it "creates nodes as needed" do
+      # Creates the Host Node
       expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('http://localhost:80/')
+        expect(args[:label]).to eq('127.0.0.1')
         expect(args[:type]).to eq(:host)
         OpenStruct.new(args)
       end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("http://localhost:80/")
-        expect(args[:text]).to include("#[Title]#\nNikto upload: localhost.xml")
-        expect(args[:text]).to_not include("not recognized by the plugin")
+      run_import!
+    end
+
+    it "creates issues as needed" do
+      # Creates 3 Issues
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("#[Title]#\n\/\: Directory indexing found.")
         OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("http://localhost:80/")
-        expect(args[:text]).to include("SSL Cert Information")
-        expect(args[:text]).to_not include("not recognized by the plugin")
+      end
+
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("#[Title]#\nApache/2.2.16 appears to be outdated (current is at least Apache/2.2.19). Apache 1.3.42 (final release) and 2.0.64 are also current.")
         OpenStruct.new(args)
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('750000')
-        expect(args[:parent].label).to eq("http://localhost:80/")
-        OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("750000")
-        expect(args[:text]).to include("/: Directory indexing found.")
-        expect(args[:text]).to_not include("not recognized by the plugin")
-        expect(args[:text]).to include("OSVDB: \"3268\":3268_LINK")
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("#[Title]#\nAllowed HTTP Methods: GET, HEAD, POST, OPTIONS")
         OpenStruct.new(args)
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('600050')
-        expect(args[:parent].label).to eq("http://localhost:80/")
-        OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("600050")
-        expect(args[:text]).to include("Apache/2.2.16 appears to be outdated")
-        expect(args[:text]).to_not include("not recognized by the plugin")
+      run_import!
+    end
+
+    it "creates evidence as needed" do
+      # Creates 4 instances of Evidence for the 3 Issues
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include("Link: http://localhost:80/")
+        expect(args[:issue].text).to include("Directory indexing found.")
+        expect(args[:node].label).to eq("127.0.0.1")
         OpenStruct.new(args)
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('999990')
-        expect(args[:parent].label).to eq("http://localhost:80/")
-        OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("999990")
-        expect(args[:text]).to include("Allowed HTTP Methods: GET, HEAD, POST, OPTIONS")
-        expect(args[:text]).to_not include("not recognized by the plugin")
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include("Link: http://localhost:80/")
+        expect(args[:issue].text).to include("Apache/2.2.16 appears to be outdated (current is at least Apache/2.2.19). Apache 1.3.42 (final release) and 2.0.64 are also current.")
+        expect(args[:node].label).to eq("127.0.0.1")
         OpenStruct.new(args)
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('750000')
-        expect(args[:parent].label).to eq("http://localhost:80/")
-        OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:node].label).to eq("750000")
-        expect(args[:text]).to include("/?show=http://cirt.net/rfiinc.txt??: Directory indexing found.")
-        expect(args[:text]).to_not include("not recognized by the plugin")
-        expect(args[:text]).to include("OSVDB: \"n/a\":n/a")
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include("Link: http://localhost:80/")
+        expect(args[:issue].text).to include("Allowed HTTP Methods: GET, HEAD, POST, OPTIONS")
+        expect(args[:node].label).to eq("127.0.0.1")
         OpenStruct.new(args)
       end.once
 
-      # Run the import
-      @importer.import(file: 'spec/fixtures/files/localhost.xml')
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include("Link: http://localhost:80/?show=http://cirt.net/rfiinc.txt??")
+        expect(args[:issue].text).to include("Directory indexing found.")
+        expect(args[:node].label).to eq("127.0.0.1")
+        OpenStruct.new(args)
+      end.once
+
+      run_import!
     end
 
   end

--- a/spec/nikto_upload_spec.rb
+++ b/spec/nikto_upload_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'ostruct'
 
 module Dradis::Plugins
   describe 'Nikto upload plugin' do

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,0 +1,4 @@
+item.request_method
+item.uri
+item.namelink
+item.iplink

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -1,0 +1,6 @@
+<item id="750000" method="GET" osvdbid="3268" osvdblink="3268_LINK">
+  <description><![CDATA[/: Directory indexing found.]]></description>
+  <uri><![CDATA[/]]></uri>
+  <namelink><![CDATA[http://localhost:80/]]></namelink>
+  <iplink><![CDATA[http://127.0.0.1:80/]]></iplink>
+</item>

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,0 +1,6 @@
+#[Request]#
+Request Method: %item.request_method%
+
+#[Links]#
+Link: %item.namelink%
+IP Based Link: %item.iplink%

--- a/templates/item.template
+++ b/templates/item.template
@@ -1,10 +1,8 @@
-#[Title]#
-Finding
-
+##[Title]#
+%item.description%
 
 #[Details]#
-OSVDB: "%item.osvdbid%":%item.osvdblink%
-Request Method: %item.request_method%
-Description: %item.description%
-Link: %item.namelink%
-IP Based Link: %item.iplink%
+%item.description%
+
+#[OSVDB]#
+"%item.osvdbid%":%item.osvdblink%


### PR DESCRIPTION
Previously, the Nikto plugin created subnodes for each finding `id` and Notes for each finding. 

This PR creates Issues from each finding `id` and a piece of Evidence for each instance of that finding. 

This PR also resolves: https://github.com/dradis/dradis-ce/issues/134 by naming the Node from the `targetip`. 