### PR TITLE
Niktoscan update <niktoscan> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.15 (September, 2019) ##
+
+*   Added an extra set of `<niktoscan>` tags after a change in Nikto XML structure.
+
 ## Dradis Framework 3.14 (August, 2019) ##
 
 *   No changes.

--- a/lib/dradis/plugins/nikto/importer.rb
+++ b/lib/dradis/plugins/nikto/importer.rb
@@ -18,14 +18,14 @@ module Dradis::Plugins::Nikto
       doc = Nokogiri::XML(xml)
       logger.info{ 'Done.' }
 
-      if doc.xpath('/nikto/niktoscan/niktoscan/scandetails').empty?
+      if doc.xpath('//niktoscan/scandetails').empty?
         error = "No scan results were detected in the uploaded file (/nikto/niktoscan/scandetails). Ensure you uploaded a Nikto XML report."
         logger.fatal{ error }
         content_service.create_note text: error
         return false
       end
 
-      doc.xpath('/nikto/niktoscan/niktoscan/scandetails').each do |xml_scan|
+      doc.xpath('//niktoscan/scandetails').each do |xml_scan|
         host_label = xml_scan['targetip']
 
         # Hack to include the file name in the xml

--- a/lib/dradis/plugins/nikto/importer.rb
+++ b/lib/dradis/plugins/nikto/importer.rb
@@ -18,14 +18,14 @@ module Dradis::Plugins::Nikto
       doc = Nokogiri::XML(xml)
       logger.info{ 'Done.' }
 
-      if doc.xpath('/nikto/niktoscan/scandetails').empty?
+      if doc.xpath('/nikto/niktoscan/niktoscan/scandetails').empty?
         error = "No scan results were detected in the uploaded file (/nikto/niktoscan/scandetails). Ensure you uploaded a Nikto XML report."
         logger.fatal{ error }
         content_service.create_note text: error
         return false
       end
 
-      doc.xpath('/nikto/niktoscan/scandetails').each do |xml_scan|
+      doc.xpath('/nikto/niktoscan/niktoscan/scandetails').each do |xml_scan|
         host_label = xml_scan['targetip']
 
         # Hack to include the file name in the xml

--- a/spec/fixtures/files/localhost.xml
+++ b/spec/fixtures/files/localhost.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
 <niktoscan hoststest="0" options="-h localhost -p 80 -out /tmp/localhost.xml" version="2.1.4" scanstart="Sun Jul 17 19:54:10 2011" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.1">
 <scandetails targetip="127.0.0.1" targethostname="localhost" targetport="80" targetbanner="Apache/2.2.16 (Debian)" starttime="2011-07-18 19:54:10" sitename="http://localhost:80/" siteip="http://127.0.0.1:80/" hostheader="localhost">
 <ssl ciphers="DHE-RSA-AES256-SHA" issuers="/C=GB/ST=Berks/L=Ruscombe/O=XXXXXX/OU=XXXX/CN=asdf.com/emailAddress=someoneatasdf.com" info="/C=GB/ST=Berkshire/L=Ruscombe/O=Company/OU=UK/CN=vmx098" />
@@ -35,5 +36,6 @@
 <statistics elapsed="10" itemsfound="44" itemstested="6456" endtime="2011-07-18 19:54:20" />
 </scandetails>
 
-
+</niktoscan>
+  
 </niktoscan>


### PR DESCRIPTION
### Summary

With a recent update, Nikto XML files have two sets of <niktoscan> tags.  This PR allows for that so that Nikto XML file uploads are parsed correctly.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
